### PR TITLE
save temp mmemap files with four digits

### DIFF
--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -106,7 +106,7 @@ def save_memmap_each(fnames, dview=None, base_name=None, resize_fact=(1, 1, 1), 
 
     for idx,f in enumerate(fnames):
         if base_name is not None:
-            pars.append([f,base_name+str(idx),resize_fact[idx],remove_init,idx_xy,order,xy_shifts[idx],add_to_movie,border_to_0])
+            pars.append([f,base_name+'{:04d}'.format(idx),resize_fact[idx],remove_init,idx_xy,order,xy_shifts[idx],add_to_movie,border_to_0])
         else:
             pars.append([f,os.path.splitext(f)[0],resize_fact[idx],remove_init,idx_xy,order,xy_shifts[idx],add_to_movie,border_to_0])            
 


### PR DESCRIPTION
I've noted a small bug in the function save_memmap_each (line 109 of file mmaping.py). I would suggest instead of: base_name+str(idx), to write instead: base_name+'{:04d}'.format(idx) . The reason is that after this function is called in the main code, you do: name_new.sort(). The problem is if you have the data contained in more than 10 tiff files, then you'll have a mismatch because the order will be the following: _1,_10,_11,.._19,_2,_20,_21,...,_3.. and so on.